### PR TITLE
bugfix: Replaced reference to non-existing field

### DIFF
--- a/tasks/qamnist/train.py
+++ b/tasks/qamnist/train.py
@@ -148,7 +148,6 @@ if __name__=='__main__':
         device = 'mps'
     else:
         device = 'cpu'
-    print(f'Running model {args.d_model} on {device}')
 
     # Build model
     model = prepare_model(args, device)

--- a/tasks/qamnist/train.py
+++ b/tasks/qamnist/train.py
@@ -148,7 +148,7 @@ if __name__=='__main__':
         device = 'mps'
     else:
         device = 'cpu'
-    print(f'Running model {args.model} on {device}')
+    print(f'Running model {args.d_model} on {device}')
 
     # Build model
     model = prepare_model(args, device)
@@ -213,7 +213,7 @@ if __name__=='__main__':
             test_accuracies = checkpoint['test_accuracies']
             iters = checkpoint['iters']
         else:
-            print('Only relading model!')
+            print('Only reloading model!')
         if 'torch_rng_state' in checkpoint:
             # Reset seeds, otherwise mid-way training can be obscure (particularly for imagenet)
             torch.set_rng_state(checkpoint['torch_rng_state'].cpu().byte())


### PR DESCRIPTION
When running the training script with `tasks/qamnist/train.py`, the following line produces an error since the `model` field does not exist in `args`
```
print(f'Running model {args.model} on {device}')
```
This PR fixes the problem by replacing `args.model` with the correct `args.d_model`