### PR TITLE
Cross platform

### DIFF
--- a/models/ctm.py
+++ b/models/ctm.py
@@ -239,11 +239,9 @@ class ContinuousThoughtMachine(nn.Module, PyTorchModelHubMixin):
                 selected_left = activated_state[:, neuron_indices_left]
                 selected_right = activated_state[:, neuron_indices_right]
             
-            # Compute outer product of selected neurons
-            outer = selected_left.unsqueeze(2) * selected_right.unsqueeze(1)
-            # Resulting matrix is symmetric, so we only need the upper triangle
-            i, j = torch.triu_indices(n_synch, n_synch)
-            pairwise_product = outer[:, i, j]
+            # Compute pairwise products efficiently without intermediate tensor
+            i, j = torch.triu_indices(n_synch, n_synch, device=activated_state.device)
+            pairwise_product = selected_left[:, i] * selected_right[:, j]
             
         elif self.neuron_select_type == 'random-pairing':
             # For random-pairing, we compute the sync between specific pairs of neurons

--- a/utils/housekeeping.py
+++ b/utils/housekeeping.py
@@ -20,7 +20,7 @@ def zip_python_code(output_filename):
     with zipfile.ZipFile(output_filename, 'w') as zipf:
         files = glob.glob('models/**/*.py', recursive=True) + glob.glob('utils/**/*.py', recursive=True) + glob.glob('tasks/**/*.py', recursive=True) + glob.glob('*.py', recursive=True)
         for file in files:
-            zipf.write(file, arcname=file)
+            zipf.write(file, arcname=file.replace(os.sep, '/'))
 
 def set_seed(seed=42, deterministic=True):
     """

--- a/utils/housekeeping.py
+++ b/utils/housekeeping.py
@@ -9,20 +9,18 @@ import glob
 
 def zip_python_code(output_filename):
     """
-    Zips all .py files in the current repository and saves it to the 
+    Zips all .py files in the current repository and saves it to the
     specified output filename.
 
     Args:
-        output_filename: The name of the output zip file. 
+        output_filename: The name of the output zip file.
                          Defaults to "python_code_backup.zip".
     """
 
     with zipfile.ZipFile(output_filename, 'w') as zipf:
         files = glob.glob('models/**/*.py', recursive=True) + glob.glob('utils/**/*.py', recursive=True) + glob.glob('tasks/**/*.py', recursive=True) + glob.glob('*.py', recursive=True)
         for file in files:
-            root = '/'.join(file.split('/')[:-1])
-            nm = file.split('/')[-1]
-            zipf.write(os.path.join(root, nm))
+            zipf.write(file, arcname=file)
 
 def set_seed(seed=42, deterministic=True):
     """


### PR DESCRIPTION
- Previous implementation hardcoded Unix-style separators and could write `\` into zip entries on Windows, breaking extraction and structure.
- ZIP specification requires `/` inside archives; this fix enforces that across all platforms.