### PR TITLE
early_stopping_best_model_checkpointing

### DIFF
--- a/models/ctm.py
+++ b/models/ctm.py
@@ -239,11 +239,9 @@ class ContinuousThoughtMachine(nn.Module, PyTorchModelHubMixin):
                 selected_left = activated_state[:, neuron_indices_left]
                 selected_right = activated_state[:, neuron_indices_right]
             
-            # Compute outer product of selected neurons
-            outer = selected_left.unsqueeze(2) * selected_right.unsqueeze(1)
-            # Resulting matrix is symmetric, so we only need the upper triangle
-            i, j = torch.triu_indices(n_synch, n_synch)
-            pairwise_product = outer[:, i, j]
+            # Compute pairwise products efficiently without intermediate tensor
+            i, j = torch.triu_indices(n_synch, n_synch, device=activated_state.device)
+            pairwise_product = selected_left[:, i] * selected_right[:, j]
             
         elif self.neuron_select_type == 'random-pairing':
             # For random-pairing, we compute the sync between specific pairs of neurons

--- a/tasks/image_classification/train.py
+++ b/tasks/image_classification/train.py
@@ -119,6 +119,9 @@ def parse_args():
     parser.add_argument('--device', type=int, nargs='+', default=[-1], help='List of GPU(s) to use. Set to -1 to use CPU.')
     parser.add_argument('--use_amp', action=argparse.BooleanOptionalAction, default=False, help='AMP autocast.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if test metric does not improve for this many validations. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
 
     args = parser.parse_args()
     return args
@@ -326,6 +329,9 @@ if __name__=='__main__':
     train_accuracies_most_certain = [] if args.model in ['ctm', 'lstm'] else None
     test_accuracies_most_certain = [] if args.model in ['ctm', 'lstm'] else None
 
+    best_test_metric = -float('inf')
+    early_stopping_counter = 0
+
     scaler = torch.amp.GradScaler("cuda" if "cuda" in device else "cpu", enabled=args.use_amp)
 
     # Reloading logic
@@ -355,6 +361,10 @@ if __name__=='__main__':
                 if args.model in ['ctm', 'lstm']:
                     train_accuracies_most_certain = checkpoint['train_accuracies_most_certain']
                     test_accuracies_most_certain = checkpoint['test_accuracies_most_certain']
+
+                # Load early stopping state (backward compatible)
+                best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+                early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
 
             else:
                 print('Only reloading model!')
@@ -567,6 +577,26 @@ if __name__=='__main__':
                          current_test_accuracies = (all_targets == all_predictions).mean()
                          test_accuracies.append(current_test_accuracies)
 
+                # Best model checkpoint and early stopping
+                if args.model in ['ctm', 'lstm']:
+                    current_metric = current_test_accuracies_most_certain
+                else:
+                    current_metric = current_test_accuracies
+                if current_metric > best_test_metric:
+                    best_test_metric = current_metric
+                    early_stopping_counter = 0
+                    if args.save_best_checkpoint:
+                        torch.save({'model_state_dict': model.state_dict(),
+                                     'iteration': bi, 'best_test_metric': best_test_metric, 'args': args},
+                                    f'{args.log_dir}/best_checkpoint.pt')
+                        print(f'New best model saved at iteration {bi} with metric {best_test_metric:.4f}')
+                else:
+                    early_stopping_counter += 1
+                    if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                        print(f'Early stopping triggered at iteration {bi}. '
+                              f'No improvement for {args.early_stopping_patience} validations.')
+                        break
+
                 # Plotting (conditional)
                 figacc = plt.figure(figsize=(10, 10))
                 axacc_train = figacc.add_subplot(211)
@@ -675,6 +705,9 @@ if __name__=='__main__':
                     'test_accuracies': test_accuracies, # This is list of scalars for FF, list of arrays for CTM/LSTM
                     'iters': iters,
                     'args': args, # Save args used for this run
+                    # Early stopping state
+                    'best_test_metric': best_test_metric,
+                    'early_stopping_counter': early_stopping_counter,
                     # RNG states
                     'torch_rng_state': torch.get_rng_state(),
                     'numpy_rng_state': np.random.get_state(),

--- a/tasks/mazes/train.py
+++ b/tasks/mazes/train.py
@@ -126,6 +126,9 @@ def parse_args():
     parser.add_argument('--device', type=int, nargs='+', default=[-1], help='List of GPU(s) to use. Set to -1 to use CPU.')
     parser.add_argument('--use_amp', action=argparse.BooleanOptionalAction, default=False, help='AMP autocast.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if test metric does not improve for this many validations. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
 
     args = parser.parse_args()
     return args
@@ -287,6 +290,9 @@ if __name__=='__main__':
     test_accuracies_most_certain_permaze = []  
     iters = []
 
+    best_test_metric = -float('inf')
+    early_stopping_counter = 0
+
     scaler = torch.amp.GradScaler("cuda" if "cuda" in device else "cpu", enabled=args.use_amp)
     if args.reload:
         checkpoint_path = f'{args.log_dir}/checkpoint.pt'
@@ -316,6 +322,10 @@ if __name__=='__main__':
                     test_accuracies_most_certain_permaze = checkpoint['test_accuracies_most_certain_permaze']
                 else:
                      print("Ignoring metrics history upon reload.")
+
+                # Load early stopping state (backward compatible)
+                best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+                early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
 
             else:
                 print('Only reloading model!')
@@ -587,89 +597,105 @@ if __name__=='__main__':
                     # Calculate full maze accuracy
                     test_accuracies_most_certain_permaze.append((all_targets == all_predictions_most_certain).reshape(all_targets.shape[0], -1).all(-1).mean()) # Scalar
 
+                # Best model checkpoint and early stopping
+                current_metric = test_accuracies_most_certain_permaze[-1]
+                if current_metric > best_test_metric:
+                    best_test_metric = current_metric
+                    early_stopping_counter = 0
+                    if args.save_best_checkpoint:
+                        torch.save({'model_state_dict': model.state_dict(),
+                                     'iteration': bi, 'best_test_metric': best_test_metric, 'args': args},
+                                    f'{args.log_dir}/best_checkpoint.pt')
+                        print(f'New best model saved at iteration {bi} with metric {best_test_metric:.4f}')
+                else:
+                    early_stopping_counter += 1
+                    if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                        print(f'Early stopping triggered at iteration {bi}. '
+                              f'No improvement for {args.early_stopping_patience} validations.')
+                        break
 
-                    # --- Plotting ---
-                    # Accuracy Plot (Handling different dimensions)
-                    figacc = plt.figure(figsize=(10, 10))
-                    axacc_train = figacc.add_subplot(211)
-                    axacc_test = figacc.add_subplot(212)
-                    cm = sns.color_palette("viridis", as_cmap=True)
+                # --- Plotting ---
+                # Accuracy Plot (Handling different dimensions)
+                figacc = plt.figure(figsize=(10, 10))
+                axacc_train = figacc.add_subplot(211)
+                axacc_test = figacc.add_subplot(212)
+                cm = sns.color_palette("viridis", as_cmap=True)
 
-                    # Plot per step/tick accuracy
-                    # train_accuracies is List[(S, T)] or List[(S,)]
-                    # We need to average over S dimension for plotting
-                    train_acc_plot = [np.mean(acc_s) for acc_s in train_accuracies] # List[Scalar] or List[Scalar] after mean
-                    test_acc_plot = [np.mean(acc_s) for acc_s in test_accuracies]   # List[Scalar] or List[Scalar] after mean
+                # Plot per step/tick accuracy
+                # train_accuracies is List[(S, T)] or List[(S,)]
+                # We need to average over S dimension for plotting
+                train_acc_plot = [np.mean(acc_s) for acc_s in train_accuracies] # List[Scalar] or List[Scalar] after mean
+                test_acc_plot = [np.mean(acc_s) for acc_s in test_accuracies]   # List[Scalar] or List[Scalar] after mean
 
-                    axacc_train.plot(iters, train_acc_plot, 'g-', alpha=0.5, label='Avg Step Acc')
-                    axacc_test.plot(iters, test_acc_plot, 'g-', alpha=0.5, label='Avg Step Acc')
+                axacc_train.plot(iters, train_acc_plot, 'g-', alpha=0.5, label='Avg Step Acc')
+                axacc_test.plot(iters, test_acc_plot, 'g-', alpha=0.5, label='Avg Step Acc')
 
 
-                    # Plot most certain accuracy 
-                    axacc_train.plot(iters, train_accuracies_most_certain, 'k--', alpha=0.7, label='Most Certain (Avg Step)')
-                    axacc_test.plot(iters, test_accuracies_most_certain, 'k--', alpha=0.7, label='Most Certain (Avg Step)')
-                    # Plot full maze accuracy 
-                    axacc_train.plot(iters, train_accuracies_most_certain_permaze, 'r-', alpha=0.6, label='Full Maze')
-                    axacc_test.plot(iters, test_accuracies_most_certain_permaze, 'r-', alpha=0.6, label='Full Maze')
+                # Plot most certain accuracy
+                axacc_train.plot(iters, train_accuracies_most_certain, 'k--', alpha=0.7, label='Most Certain (Avg Step)')
+                axacc_test.plot(iters, test_accuracies_most_certain, 'k--', alpha=0.7, label='Most Certain (Avg Step)')
+                # Plot full maze accuracy
+                axacc_train.plot(iters, train_accuracies_most_certain_permaze, 'r-', alpha=0.6, label='Full Maze')
+                axacc_test.plot(iters, test_accuracies_most_certain_permaze, 'r-', alpha=0.6, label='Full Maze')
 
-                    axacc_train.set_title('Train Accuracy')
-                    axacc_test.set_title('Test Accuracy')
-                    axacc_train.legend(loc='lower right')
-                    axacc_test.legend(loc='lower right')
-                    axacc_train.set_xlim([0, args.training_iterations])
-                    axacc_test.set_xlim([0, args.training_iterations])
-                    axacc_train.set_ylim([0, 1]) # Set Ylim for accuracy
-                    axacc_test.set_ylim([0, 1])
+                axacc_train.set_title('Train Accuracy')
+                axacc_test.set_title('Test Accuracy')
+                axacc_train.legend(loc='lower right')
+                axacc_test.legend(loc='lower right')
+                axacc_train.set_xlim([0, args.training_iterations])
+                axacc_test.set_xlim([0, args.training_iterations])
+                axacc_train.set_ylim([0, 1]) # Set Ylim for accuracy
+                axacc_test.set_ylim([0, 1])
 
-                    figacc.tight_layout()
-                    figacc.savefig(f'{args.log_dir}/accuracies.png', dpi=150)
-                    plt.close(figacc)
+                figacc.tight_layout()
+                figacc.savefig(f'{args.log_dir}/accuracies.png', dpi=150)
+                plt.close(figacc)
 
-                    # Loss Plot
-                    figloss = plt.figure(figsize=(10, 5))
-                    axloss = figloss.add_subplot(111)
-                    axloss.plot(iters, train_losses, 'b-', linewidth=1, alpha=0.8, label=f'Train: {train_losses[-1]:.4f}')
-                    axloss.plot(iters, test_losses, 'r-', linewidth=1, alpha=0.8, label=f'Test: {test_losses[-1]:.4f}')
-                    axloss.legend(loc='upper right')
-                    axloss.set_xlim([0, args.training_iterations])
-                    axloss.set_ylim(bottom=0) 
+                # Loss Plot
+                figloss = plt.figure(figsize=(10, 5))
+                axloss = figloss.add_subplot(111)
+                axloss.plot(iters, train_losses, 'b-', linewidth=1, alpha=0.8, label=f'Train: {train_losses[-1]:.4f}')
+                axloss.plot(iters, test_losses, 'r-', linewidth=1, alpha=0.8, label=f'Test: {test_losses[-1]:.4f}')
+                axloss.legend(loc='upper right')
+                axloss.set_xlim([0, args.training_iterations])
+                axloss.set_ylim(bottom=0)
 
-                    figloss.tight_layout()
-                    figloss.savefig(f'{args.log_dir}/losses.png', dpi=150)
-                    plt.close(figloss)
+                figloss.tight_layout()
+                figloss.savefig(f'{args.log_dir}/losses.png', dpi=150)
+                plt.close(figloss)
 
-                    # --- Visualization Section (Conditional) ---
-                    if args.model in ['ctm', 'lstm']:
-                        #  try:
-                            inputs_viz, targets_viz = next(iter(testloader))
-                            inputs_viz = inputs_viz.to(device)
-                            targets_viz = targets_viz.to(device)
-                            # Find longest path in batch for potentially better visualization
-                            longest_index = (targets_viz!=4).sum(-1).argmax() # Action 4 assumed padding/end
+                # --- Visualization Section (Conditional) ---
+                if args.model in ['ctm', 'lstm']:
+                    #  try:
+                        inputs_viz, targets_viz = next(iter(testloader))
+                        inputs_viz = inputs_viz.to(device)
+                        targets_viz = targets_viz.to(device)
+                        # Find longest path in batch for potentially better visualization
+                        longest_index = (targets_viz!=4).sum(-1).argmax() # Action 4 assumed padding/end
 
-                            # Track internal states
-                            predictions_viz_raw, certainties_viz, _, pre_activations_viz, post_activations_viz, attention_tracking_viz = model(inputs_viz, track=True)
+                        # Track internal states
+                        predictions_viz_raw, certainties_viz, _, pre_activations_viz, post_activations_viz, attention_tracking_viz = model(inputs_viz, track=True)
 
-                            # Reshape predictions (assuming raw is B, D, T)
-                            predictions_viz = predictions_viz_raw.reshape(predictions_viz_raw.size(0), -1, 5, predictions_viz_raw.size(-1)) # B, S, C, T
+                        # Reshape predictions (assuming raw is B, D, T)
+                        predictions_viz = predictions_viz_raw.reshape(predictions_viz_raw.size(0), -1, 5, predictions_viz_raw.size(-1)) # B, S, C, T
 
-                            att_shape = (model.kv_features.shape[2], model.kv_features.shape[3])
-                            attention_tracking_viz = attention_tracking_viz.reshape(
-                                attention_tracking_viz.shape[0], 
-                                attention_tracking_viz.shape[1], -1, att_shape[0], att_shape[1])
+                        att_shape = (model.kv_features.shape[2], model.kv_features.shape[3])
+                        attention_tracking_viz = attention_tracking_viz.reshape(
+                            attention_tracking_viz.shape[0],
+                            attention_tracking_viz.shape[1], -1, att_shape[0], att_shape[1])
 
-                            # Plot dynamics (common plotting function)
-                            plot_neural_dynamics(post_activations_viz, 100, args.log_dir, axis_snap=True)
+                        # Plot dynamics (common plotting function)
+                        plot_neural_dynamics(post_activations_viz, 100, args.log_dir, axis_snap=True)
 
-                            # Create maze GIF (task-specific plotting)
-                            make_maze_gif((inputs_viz[longest_index].detach().cpu().numpy()+1)/2,
-                                          predictions_viz[longest_index].detach().cpu().numpy(), # Pass reshaped B,S,C,T -> S,C,T
-                                          targets_viz[longest_index].detach().cpu().numpy(), # S
-                                          attention_tracking_viz[:, longest_index],  # Pass T, (H), H, W
-                                          args.log_dir)
-                        #  except Exception as e:
-                        #       print(f"Visualization failed for model {args.model}: {e}")
-                    # --- End Visualization ---
+                        # Create maze GIF (task-specific plotting)
+                        make_maze_gif((inputs_viz[longest_index].detach().cpu().numpy()+1)/2,
+                                      predictions_viz[longest_index].detach().cpu().numpy(), # Pass reshaped B,S,C,T -> S,C,T
+                                      targets_viz[longest_index].detach().cpu().numpy(), # S
+                                      attention_tracking_viz[:, longest_index],  # Pass T, (H), H, W
+                                      args.log_dir)
+                    #  except Exception as e:
+                    #       print(f"Visualization failed for model {args.model}: {e}")
+                # --- End Visualization ---
 
                 model.train() # Switch back to train mode
 
@@ -694,6 +720,9 @@ if __name__=='__main__':
                     'test_accuracies_most_certain_permaze': test_accuracies_most_certain_permaze,   # List of scalars
                     'iters': iters,
                     'args': args, # Save args used for this run
+                    # Early stopping state
+                    'best_test_metric': best_test_metric,
+                    'early_stopping_counter': early_stopping_counter,
                     # RNG states
                     'torch_rng_state': torch.get_rng_state(),
                     'numpy_rng_state': np.random.get_state(),

--- a/tasks/parity/train.py
+++ b/tasks/parity/train.py
@@ -81,6 +81,10 @@ def parse_args():
     parser.add_argument('--device', type=int, nargs='+', default=[-1], help='GPU(s) or -1 for CPU.')
     parser.add_argument('--use_amp', action=argparse.BooleanOptionalAction, default=False, help='AMP autocast.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if test metric does not improve for this many validations. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
+
     args = parser.parse_args()
     return args
 
@@ -163,6 +167,8 @@ if __name__=='__main__':
     train_accuracies_most_certain_per_input = []
     test_accuracies_most_certain_per_input = []
     iters = []
+    best_test_metric = -float('inf')
+    early_stopping_counter = 0
     scaler = torch.amp.GradScaler("cuda" if "cuda" in device else "cpu", enabled=args.use_amp)
 
     # Now that everything is initliased, reload if desired
@@ -185,6 +191,9 @@ if __name__=='__main__':
             test_accuracies_most_certain_per_input = checkpoint['test_accuracies_most_certain_per_input'] if 'test_accuracies_most_certain_per_input' in checkpoint else test_accuracies_most_certain_per_input
             test_accuracies = checkpoint['test_accuracies']
             iters = checkpoint['iters']
+            # Load early stopping state (backward compatible)
+            best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+            early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
         else:
             print('Only relading model!')
         if 'torch_rng_state' in checkpoint:
@@ -337,7 +346,19 @@ if __name__=='__main__':
                         test_accuracies_most_certain.append((all_targets == all_predictions_most_certain).mean())
                         test_accuracies_most_certain_per_input.append((all_targets == all_predictions_most_certain).reshape(all_targets.shape[0], -1).all(-1).mean())
                         test_losses.append(np.mean(all_losses))
-                            
+
+                        # Best model checkpoint and early stopping
+                        current_metric = test_accuracies_most_certain[-1]
+                        if current_metric > best_test_metric:
+                            best_test_metric = current_metric
+                            early_stopping_counter = 0
+                            if args.save_best_checkpoint:
+                                torch.save({'model_state_dict': model.state_dict(),
+                                             'iteration': bi, 'best_test_metric': best_test_metric, 'args': args},
+                                            f'{args.log_dir}/best_checkpoint.pt')
+                                print(f'New best model saved at iteration {bi} with metric {best_test_metric:.4f}')
+                        else:
+                            early_stopping_counter += 1
 
                         figacc = plt.figure(figsize=(10, 10))
                         axacc_train = figacc.add_subplot(211)
@@ -345,18 +366,18 @@ if __name__=='__main__':
                         cm = sns.color_palette("viridis", as_cmap=True)
                         if args.dataset != 'sort':
                             for ti, (train_acc, test_acc) in enumerate(zip(np.array(train_accuracies).T, np.array(test_accuracies).T)):
-                                axacc_train.plot(iters, train_acc, color=cm((ti)/(train_accuracies[0].shape[-1])), alpha=0.3)       
-                                axacc_test.plot(iters, test_acc, color=cm((ti)/(test_accuracies[0].shape[-1])), alpha=0.3)  
-                        axacc_train.plot(iters, train_accuracies_most_certain, 'k--', alpha=0.7, label='Most certain')   
-                        axacc_train.plot(iters, train_accuracies_most_certain_per_input, 'r', alpha=0.6, label='Full Input')        
-                        axacc_test.plot(iters, test_accuracies_most_certain, 'k--', alpha=0.7, label='Most certain')        
-                        axacc_test.plot(iters, test_accuracies_most_certain_per_input, 'r', alpha=0.6, label='Full Input')        
+                                axacc_train.plot(iters, train_acc, color=cm((ti)/(train_accuracies[0].shape[-1])), alpha=0.3)
+                                axacc_test.plot(iters, test_acc, color=cm((ti)/(test_accuracies[0].shape[-1])), alpha=0.3)
+                        axacc_train.plot(iters, train_accuracies_most_certain, 'k--', alpha=0.7, label='Most certain')
+                        axacc_train.plot(iters, train_accuracies_most_certain_per_input, 'r', alpha=0.6, label='Full Input')
+                        axacc_test.plot(iters, test_accuracies_most_certain, 'k--', alpha=0.7, label='Most certain')
+                        axacc_test.plot(iters, test_accuracies_most_certain_per_input, 'r', alpha=0.6, label='Full Input')
                         axacc_train.set_title('Train')
                         axacc_test.set_title('Test')
                         axacc_train.legend(loc='lower right')
                         axacc_train.set_xlim([0, args.training_iterations])
                         axacc_test.set_xlim([0, args.training_iterations])
-                        
+
                         figacc.tight_layout()
                         figacc.savefig(f'{args.log_dir}/accuracies.png', dpi=150)
                         plt.close(figacc)
@@ -373,9 +394,11 @@ if __name__=='__main__':
                         plt.close(figloss)
 
                 model.train()
-                            
 
-
+                if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                    print(f'Early stopping triggered at iteration {bi}. '
+                          f'No improvement for {args.early_stopping_patience} validations.')
+                    break
 
             # Save model
             if (bi%args.save_every==0 or bi==args.training_iterations-1):
@@ -396,6 +419,8 @@ if __name__=='__main__':
                     'test_losses':test_losses,
                     'iters':iters,
                     'args':args,
+                    'best_test_metric': best_test_metric,
+                    'early_stopping_counter': early_stopping_counter,
                     'torch_rng_state': torch.get_rng_state(),
                     'numpy_rng_state': np.random.get_state(),
                     'random_rng_state': random.getstate(),

--- a/tasks/qamnist/train.py
+++ b/tasks/qamnist/train.py
@@ -108,6 +108,9 @@ def parse_args():
     parser.add_argument('--device', type=int, nargs='+', default=[-1], help='List of GPU(s) to use. Set to -1 to use CPU.')
     parser.add_argument('--use_amp', action=argparse.BooleanOptionalAction, default=False, help='AMP autocast.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if test metric does not improve for this many validations. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
 
     args = parser.parse_args()
     return args
@@ -191,6 +194,8 @@ if __name__=='__main__':
     train_accuracies_most_certain = []  # This will be selected according to what is returned by loss function
     test_accuracies_most_certain = []
     iters = []
+    best_test_metric = -float('inf')
+    early_stopping_counter = 0
     scaler = torch.amp.GradScaler("cuda" if "cuda" in device else "cpu", enabled=args.use_amp)
 
     # Now that everything is initliased, reload if desired
@@ -211,6 +216,9 @@ if __name__=='__main__':
             test_accuracies_most_certain = checkpoint['test_accuracies_most_certain']
             test_accuracies = checkpoint['test_accuracies']
             iters = checkpoint['iters']
+            # Load early stopping state (backward compatible)
+            best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+            early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
         else:
             print('Only reloading model!')
         if 'torch_rng_state' in checkpoint:
@@ -391,7 +399,19 @@ if __name__=='__main__':
                         test_accuracies.append(np.mean(all_predictions == all_targets[...,np.newaxis], axis=tuple(range(all_predictions.ndim-1))))
                         test_accuracies_most_certain.append((all_targets == all_predictions_most_certain).mean())
                         test_losses.append(np.mean(all_losses))
-                            
+
+                        # Best model checkpoint and early stopping
+                        current_metric = test_accuracies_most_certain[-1]
+                        if current_metric > best_test_metric:
+                            best_test_metric = current_metric
+                            early_stopping_counter = 0
+                            if args.save_best_checkpoint:
+                                torch.save({'model_state_dict': model.state_dict(),
+                                             'iteration': bi, 'best_test_metric': best_test_metric, 'args': args},
+                                            f'{args.log_dir}/best_checkpoint.pt')
+                                print(f'New best model saved at iteration {bi} with metric {best_test_metric:.4f}')
+                        else:
+                            early_stopping_counter += 1
 
                         figacc = plt.figure(figsize=(10, 10))
                         axacc_train = figacc.add_subplot(211)
@@ -422,9 +442,11 @@ if __name__=='__main__':
                         plt.close(figloss)
 
                 model.train()
-                            
 
-
+                if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                    print(f'Early stopping triggered at iteration {bi}. '
+                          f'No improvement for {args.early_stopping_patience} validations.')
+                    break
 
             # Save model
             if (bi%args.save_every==0 or bi==args.training_iterations-1) and bi != start_iter:
@@ -444,6 +466,8 @@ if __name__=='__main__':
                     'test_losses':test_losses,
                     'iters':iters,
                     'args':args,
+                    'best_test_metric': best_test_metric,
+                    'early_stopping_counter': early_stopping_counter,
                     'torch_rng_state': torch.get_rng_state(),
                     'numpy_rng_state': np.random.get_state(),
                     'random_rng_state': random.getstate(),

--- a/tasks/rl/train.py
+++ b/tasks/rl/train.py
@@ -79,6 +79,10 @@ def parse_args():
     parser.add_argument('--track_every', type=int, default=1000, help='Track metrics frequency.')
     parser.add_argument('--device', type=int, nargs='+', default=[-1], help='GPU(s) or -1 for CPU.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if mean episode reward does not improve for this many save intervals. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
+
     args = parser.parse_args()
     return args
 
@@ -256,7 +260,7 @@ class Agent(nn.Module):
         
         return action, action_probs.log_prob(action), action_probs.entropy(), value, ctm_state, tracking_data, action_logits, action_probs.probs
 
-def save_model(agent, optimizer, global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, args, save_path):
+def save_model(agent, optimizer, global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, args, save_path, best_test_metric=-float('inf'), early_stopping_counter=0):
     torch.save({
         'model_state_dict': agent.state_dict(),
         'optimizer_state_dict': optimizer.state_dict(),
@@ -265,7 +269,9 @@ def save_model(agent, optimizer, global_step, training_iteration, episode_reward
         'episode_rewards_tracking': episode_rewards_tracking,
         'episode_lengths_tracking': episode_lengths_tracking,
         'global_steps_tracking': global_steps_tracking,
-        'args': args
+        'args': args,
+        'best_test_metric': best_test_metric,
+        'early_stopping_counter': early_stopping_counter,
     }, save_path)
 
 def load_model(agent, optimizer, checkpoint_path, device):
@@ -393,8 +399,12 @@ if __name__ == "__main__":
     checkpoint_path = f"{args.log_dir}/checkpoint.pt"
     if os.path.exists(checkpoint_path) and args.reload:
         global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, _ = load_model(agent, optimizer, checkpoint_path, device)
+        best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+        early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
     else:
         global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking = 0, 0, [], [], []
+        best_test_metric = -float('inf')
+        early_stopping_counter = 0
 
     # Rollout buffer
     obs = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape).to(device)
@@ -583,7 +593,23 @@ if __name__ == "__main__":
             plot_activations(agent, device, args)
 
         if training_iteration % args.save_every == 0 or training_iteration == 1 or global_step == args.total_timesteps-1:
-            save_model(agent, optimizer, global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, args, f"{args.log_dir}/checkpoint.pt")
+            save_model(agent, optimizer, global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, args, f"{args.log_dir}/checkpoint.pt", best_test_metric, early_stopping_counter)
+
+            # Best model checkpoint and early stopping (based on recent episode rewards)
+            if len(episode_rewards_tracking) > 0:
+                current_metric = np.mean(episode_rewards_tracking[-100:])
+                if current_metric > best_test_metric:
+                    best_test_metric = current_metric
+                    early_stopping_counter = 0
+                    if args.save_best_checkpoint:
+                        save_model(agent, optimizer, global_step, training_iteration, episode_rewards_tracking, episode_lengths_tracking, global_steps_tracking, args, f"{args.log_dir}/best_checkpoint.pt", best_test_metric, early_stopping_counter)
+                        print(f'New best model saved at iteration {training_iteration} with mean reward {best_test_metric:.4f}')
+                else:
+                    early_stopping_counter += 1
+                    if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                        print(f'Early stopping triggered at iteration {training_iteration}. '
+                              f'No improvement for {args.early_stopping_patience} save intervals.')
+                        break
 
         y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
         var_y = np.var(y_true)

--- a/tasks/sort/train.py
+++ b/tasks/sort/train.py
@@ -118,6 +118,10 @@ def parse_args():
     parser.add_argument('--device', type=int, nargs='+', default=[-1],
                         help='List of GPU(s) to use. Set to -1 to use CPU.')
 
+    # Early stopping and best checkpoint (optional, disabled by default)
+    parser.add_argument('--early_stopping_patience', type=int, default=-1, help='Stop training if test metric does not improve for this many validations. -1 to disable.')
+    parser.add_argument('--save_best_checkpoint', action=argparse.BooleanOptionalAction, default=False, help='Save best model checkpoint separately as best_checkpoint.pt.')
+
     args = parser.parse_args()
     return args
 
@@ -246,6 +250,8 @@ if __name__=='__main__':
     train_accuracies_full_list = []  # This will be selected according to what is returned by loss function
     test_accuracies_full_list = []
     iters = []
+    best_test_metric = -float('inf')
+    early_stopping_counter = 0
 
     # Now that everything is initliased, reload if desired
     scaler = torch.amp.GradScaler("cuda" if "cuda" in device else "cpu", enabled=args.use_amp)
@@ -267,6 +273,9 @@ if __name__=='__main__':
                 test_accuracies_full_list = checkpoint['test_accuracies_full_list']
                 test_accuracies = checkpoint['test_accuracies']
                 iters = checkpoint['iters']
+                # Load early stopping state (backward compatible)
+                best_test_metric = checkpoint.get('best_test_metric', -float('inf'))
+                early_stopping_counter = checkpoint.get('early_stopping_counter', 0)
             else:
                 print('Only relading model!')
             if 'torch_rng_state' in checkpoint:
@@ -416,7 +425,19 @@ if __name__=='__main__':
                         test_accuracies.append((all_predictions==all_targets).mean())
                         test_accuracies_full_list.append((all_predictions==all_targets).all(-1).mean())
                         test_losses.append(np.mean(all_losses))
-                            
+
+                        # Best model checkpoint and early stopping
+                        current_metric = test_accuracies[-1]
+                        if current_metric > best_test_metric:
+                            best_test_metric = current_metric
+                            early_stopping_counter = 0
+                            if args.save_best_checkpoint:
+                                torch.save({'model_state_dict': model.state_dict(),
+                                             'iteration': bi, 'best_test_metric': best_test_metric, 'args': args},
+                                            f'{args.log_dir}/best_checkpoint.pt')
+                                print(f'New best model saved at iteration {bi} with metric {best_test_metric:.4f}')
+                        else:
+                            early_stopping_counter += 1
 
                         figacc = plt.figure(figsize=(10, 10))
                         axacc_train = figacc.add_subplot(211)
@@ -448,9 +469,11 @@ if __name__=='__main__':
                         plt.close(figloss)
 
                 model.train()
-                            
 
-
+                if args.early_stopping_patience != -1 and early_stopping_counter >= args.early_stopping_patience:
+                    print(f'Early stopping triggered at iteration {bi}. '
+                          f'No improvement for {args.early_stopping_patience} validations.')
+                    break
 
             # Save model
             if (bi%args.save_every==0 or bi==args.training_iterations-1) and bi != start_iter:
@@ -469,6 +492,8 @@ if __name__=='__main__':
                     'test_losses':test_losses,
                     'iters':iters,
                     'args':args,
+                    'best_test_metric': best_test_metric,
+                    'early_stopping_counter': early_stopping_counter,
                     'torch_rng_state': torch.get_rng_state(),
                     'numpy_rng_state': np.random.get_state(),
                     'random_rng_state': random.getstate(),


### PR DESCRIPTION
## Summary
- Add optional early stopping via `--early_stopping_patience N` flag (disabled by default with -1)
- Add optional best model checkpointing via `--save_best_checkpoint` flag (disabled by default)
- Applied to all 6 training scripts: image_classification, mazes, parity, qamnist, sort, and rl
- Default behavior is completely unchanged — both features are opt-in only
- Backward-compatible checkpoint loading using `.get()` with defaults

## Test plan
- [x] Verify all 6 training scripts parse correctly
- [x] Run without new flags to confirm default behavior is unchanged
- [x] Run with `--early_stopping_patience 5 --save_best_checkpoint` to verify early stopping triggers and best_checkpoint.pt is saved
- [x] Run golden tests: `python -m pytest tests/tests.py`