### PR TITLE
Fix: Remove duplicate assignment of memory_length

### DIFF
--- a/models/ctm.py
+++ b/models/ctm.py
@@ -113,7 +113,6 @@ class ContinuousThoughtMachine(nn.Module, PyTorchModelHubMixin):
         self.out_dims = out_dims
         self.positional_embedding_type = positional_embedding_type
         self.neuron_select_type = neuron_select_type
-        self.memory_length = memory_length
         dropout_nlm = dropout if dropout_nlm is None else dropout_nlm
 
         # --- Assertions ---


### PR DESCRIPTION
Found a redundant assignment of self.memory_length in the __init__ method and removed it.