### PR TITLE
Add tensorboard to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 torch
+tensorboard
 torchvision
 matplotlib
 seaborn


### PR DESCRIPTION
## Summary

Add `tensorboard` to `requirements.txt`.

## Reason

The RL training code imports `SummaryWriter` from `torch.utils.tensorboard`, but `tensorboard` is currently only mentioned as a manual install step in the RL README and is missing from the main requirements file.